### PR TITLE
Adds copy-blocking on code output.

### DIFF
--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -1,14 +1,22 @@
 import Clipboard from 'clipboard';
 
-var pre = document.getElementsByTagName('pre');
-
 for (var i = 0; i < pre.length; ++ i)
 {
   var element = pre[i];
-  var mermaid = element.getElementsByClassName('language-mermaid')[0];
 
-  if (mermaid == null) {
+  var mermaid = element.getElementsByClassName('language-mermaid')[0];
+  if (mermaid == null && (element.previousElementSibling.localName != "pre")) {
     element.insertAdjacentHTML('afterbegin', '<button class="btn btn-copy"></button>');
+    
+    if (element.nextElementSibling) {
+      if (element.nextElementSibling.localName == "pre") {
+        element.style.marginBottom = 0;
+      }
+    }
+  }
+  if (element.previousElementSibling.localName == "pre") {
+    element.style.marginTop = 0;
+    element.style.opacity = 0.5; 
   }
 }
 


### PR DESCRIPTION
This PR is a port of https://github.com/filecoin-project/lotus-docs/pull/282.

The site now looks for `<pre>` tags that have an immediate sibling that is another `<pre>` tag. If there is one, the reduces the `marginBottom` to `0`. Then on the next element (the second `<pre>` tag, it removes the copy button, sets the `marginTop` to `0`, and reduces the opacity to `0.8`.

This now means that if you've got a codeblock with an output, then you need to put the output in it's own codeblock immediately after the codeblock with the input:

````markdown
1. Install the serve package:

    ```shell
    npm install serve
    ```

    ```shell
    npm installing blah blah blah
    whatever npm outputs these days
    honestly, nobody ever reads npm output anyway.
    ```

1. Run the serve thingy:

    ```shell
    serve
    ```

    You can also run serve with a path:

    ```shell
    serve ./public
    ```
````

This outputs this:

![image](https://user-images.githubusercontent.com/9611008/173881056-a32660a8-3b3e-4023-9c44-6c1a385f7eff.png)