### PR TITLE
Fixes post pub

### DIFF
--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -35,7 +35,7 @@ Here are some use cases that are possible with the FVM. With centralized data, a
 
 ### Layer 2: data layer commitments
 
-Layers or Layer Protocols specify the set of communication protocols used on the blockchain and other traditional computer networks. Protocols are the technology that facilitates information sharing. (See [What Are Application Layer Protocols?](https://coinmarketcap.com/alexandria/article/what-are-application-layer-protocols).)
+Layers or Layer Protocols specify the set of communication protocols used on the blockchain and other traditional computer networks. Protocols are the technology that facilitates information sharing. (See [What Are Application Layer Protocols?](https://coinmarketcap.com/alexandria/article/what-are-application-layer-protocols))
 
 As a technology gets built out, it adds layers of capabilities, including the new Filecoin layer that supports smart contracts:
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -45,7 +45,7 @@ As a technology gets built out, it adds layers of capabilities, including the ne
 
 #### Layer 0: storage and retrieval layer
 
-This is the earliest version of Filecoin blockchain that could store and retrieve data.
+This is the earliest version of Filecoin blockchain, which could store and retrieve data.
 
 #### Layer 1: the state layer
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -1,11 +1,11 @@
 ---
 title: "Basics"
 description: "The Filecoin Virtual Machine (FVM) allows users to write their own smart-contracts and run them against the Filecoin network. This website contains all the documentation for the FVM project, including examples and reference material to help developers build on the FVM."
-lead: "The Filecoin Virtual Machine (FVM) enables programmers to create and deploy smart contracts on the Filecoin blockchain. With smart contracts, programmers can create new features, opening up a wide range of storage and data possibilities, that are provable and traceable."
+lead: "The Filecoin Virtual Machine (FVM) enables programmers to create and deploy smart contracts on the Filecoin blockchain. With smart contracts, programmers can create new features, opening up a wide range of storage and data possibilities, which are provable and traceable."
 menu:
-    concepts:
-        parent: "concepts-basics"
-        identifier: "developers-networks-overview"
+    concepts:
+        parent: "concepts-basics"
+        identifier: "developers-networks-overview"
 url: "/"
 weight: 0
 ---
@@ -14,9 +14,9 @@ weight: 0
 
 There has been a huge demand from the developer community for Filecoin compatibility with [Ethereum](https://ethereum.org/en/what-is-ethereum/) and [Solidity](https://en.wikipedia.org/wiki/Solidity) out of the box. With the FVM, developers can access the massive corpus of audited and battle-tested smart contracts written in Solidity for the Ethereum Virtual Machine (EVM).
 
-The FVM also supports other foreign runtimes and virtual machines, anything that compiles to [WebAssembly (WASM)](https://developer.mozilla.org/en-US/docs/WebAssembly). WASM was built for modern web browsers and supports multiple languages, including Rust and Go, which provides the flexibility we need to meet a variety of needs.
+The FVM also supports other foreign runtimes and virtual machines, anything that compiles to [WebAssembly (WASM)](https://developer.mozilla.org/en-US/docs/WebAssembly). WASM provides the flexibility we need to meet a variety of needs, because it was built for modern web browsers and supports multiple languages, including Rust and Go.
 
-Developers can adapt to the FVM in other contexts, such as the Interplanetary File System (IPFS) and Interplanetary Linked Data (IPLD), because it's not tightly-coupled to Filecoin.
+Developers can adapt to the FVM in other contexts, such as the [Interplanetary File System (IPFS)](https://docs.ipfs.io/) and [Interplanetary Linked Data (IPLD)](https://ipld.io/docs/), because it's not tightly-coupled to Filecoin.
 
 ## Vision and goals
 
@@ -26,12 +26,12 @@ To support computation on IPLD inputs, we're making it a core priority to build 
 
 Smart contracts use virtual entities, called _Actors_, to perform transactions. Actors are assigned various capabilities, carry a FIL currency balance, and can interact with other actors. Because user-defined actors will exponentially increase demand for space on the blockchain, we're looking into solutions that support speedier processing, such as:
 
-- [Hierarchical consensus](https://research.protocol.ai/blog/2022/scaling-blockchains-with-hierarchical-consensus/#:~:text=Hierarchical%20consensus%20is%20a%20framework,other%20subnet%20in%20the%20hierarchy) with parallel execution (enabling more processes to be done at the same time)
-- Sharding (a kind of partitioning that separates data into smaller, faster, more easily managed chunks)
+- [Hierarchical consensus](https://research.protocol.ai/blog/2022/scaling-blockchains-with-hierarchical-consensus/#:~:text=Hierarchical%20consensus%20is%20a%20framework,other%20subnet%20in%20the%20hierarchy) with parallel execution: Enabling more processes to be done at the same time.
+- [Sharding](https://www.sofi.com/learn/content/what-is-sharding/#:~:text=Sharding%20involves%20splitting%20a%20blockchain,a%20larger%20volume%20of%20transactions.): A kind of partitioning that separates data into smaller, faster, more easily managed chunks.
 
 ## Use cases
 
-Here are some use cases that are possible with the FVM. With centralized data centers, a lot of these use cases are incredibly hard, if not impossible. Decentralization and programmability open up a lot of possibilities.
+Here are some use cases that are possible with the FVM. With centralized data, a lot of these use cases are incredibly hard, if not impossible. Decentralization and programmability open up a lot of possibilities.
 
 ### Layer 2: data layer commitments
 
@@ -39,9 +39,9 @@ Layers or Layer Protocols specify the set of communication protocols used on the
 
 As a technology gets built out, it adds layers of capabilities, including the new Filecoin layer that supports smart contracts:
 
-- Layer 0 is our storage and retrieval layer
-- Layer 1 is our on-chain, state layer
-- Layer 2 is our off-chain, data layer
+- Layer 0: Our storage and retrieval layer
+- Layer 1: Our on-chain, state layer
+- Layer 2: Our off-chain, data layer
 
 #### Layer 0: storage and retrieval layer
 
@@ -55,9 +55,9 @@ When transactions occur on the Filecoin blockchain, they result in changes of st
 
 The introduction of the FVM with smart contracts enables access to Layer 2 off-chain data to fuel state changes that are provable and traceable end-to-end. You can provide consensus-backed commitments to make solutions such as:
 
-- Cross-chain bridges, enabling an exchange of information from one blockchain network to another.
-- Oracles, connecting blockchains to off-chain systems so they can execute based on inputs and outputs from the real world.
-- Rollups, rolling up multiple transactions into a single piece of data before submitting it to the blockchain.
+- Cross-chain bridges: Enabling an exchange of information from one blockchain network to another.
+- Oracles: Connecting blockchains to off-chain systems so they can execute based on inputs and outputs from the real world.
+- Rollups: Rolling up multiple transactions into a single piece of data before submitting it to the blockchain.
 - Payment networks
 
 ### Dataverse and Data DAOs
@@ -79,7 +79,7 @@ If you chain these processes together, you can compound the value of the dataset
 
 Using these datasets, you could automatically fund [Decentralized Autonomous Organizations (DAOs)](https://en.wikipedia.org/wiki/Decentralized_autonomous_organization), member-owned communities, constructed by rules encoded in a computer program.
 
-## Smart storage markets
+### Smart storage markets
 
 Smart contracts on the FVM can bring richer deal-making functionality by introducing more automation.
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -14,7 +14,7 @@ weight: 0
 
 There has been a huge demand from the developer community for Filecoin compatibility with [Ethereum](https://ethereum.org/en/what-is-ethereum/) and [Solidity](https://en.wikipedia.org/wiki/Solidity) out of the box. With the FVM, developers can access the massive corpus of audited and battle-tested smart contracts written in Solidity for the Ethereum Virtual Machine (EVM).
 
-The FVM also supports other foreign runtimes and virtual machines, anything that compiles to [WebAssembly (WASM)](https://developer.mozilla.org/en-US/docs/WebAssembly). WASM provides the flexibility we need to meet a variety of needs, because it was built for modern web browsers and supports multiple languages, including Rust and Go.
+The FVM also supports other foreign runtimes and virtual machines, anything that compiles to [WebAssembly (WASM)](https://developer.mozilla.org/en-US/docs/WebAssembly). WASM provides the flexibility we need to meet various needs because it was built for modern web browsers and supports multiple languages, including Rust and Go.
 
 Developers can adapt to the FVM in other contexts, such as the [Interplanetary File System (IPFS)](https://docs.ipfs.io/) and [Interplanetary Linked Data (IPLD)](https://ipld.io/docs/), because it's not tightly-coupled to Filecoin.
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -39,9 +39,9 @@ Layers or Layer Protocols specify the set of communication protocols used on the
 
 As a technology gets built out, it adds layers of capabilities, including the new Filecoin layer that supports smart contracts:
 
-- Layer 0: Our storage and retrieval layer
-- Layer 1: Our on-chain, state layer
-- Layer 2: Our off-chain, data layer
+- Layer 0: Storage and retrieval
+- Layer 1: On-chain, state changes
+- Layer 2: Off-chain, data access
 
 #### Layer 0: storage and retrieval layer
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -57,7 +57,7 @@ The introduction of the FVM with smart contracts enables access to Layer 2 off-c
 
 - Cross-chain bridges: Enabling an exchange of information from one blockchain network to another.
 - Oracles: Connecting blockchains to off-chain systems so they can execute based on inputs and outputs from the real world.
-- Rollups: Rolling up multiple transactions into a single piece of data before submitting it to the blockchain.
+- Rollups: Combining multiple transactions into a single piece of data before submitting it to the blockchain.
 - Payment networks
 
 ### Dataverse and Data DAOs

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -16,7 +16,7 @@ There has been a huge demand from the developer community for Filecoin compatibi
 
 The FVM also supports other foreign runtimes and virtual machines, anything that compiles to [WebAssembly (WASM)](https://developer.mozilla.org/en-US/docs/WebAssembly). WASM provides the flexibility we need to meet various needs because it was built for modern web browsers and supports multiple languages, including Rust and Go.
 
-Developers can adapt to the FVM in other contexts, such as the [Interplanetary File System (IPFS)](https://docs.ipfs.io/) and [Interplanetary Linked Data (IPLD)](https://ipld.io/docs/), because it's not tightly-coupled to Filecoin.
+Developers can adapt to the FVM in other contexts, such as the [Interplanetary File System (IPFS)](https://docs.ipfs.io/) and [Interplanetary Linked Data (IPLD)](https://ipld.io/docs/), because the FVM is not tightly-coupled to Filecoin.
 
 ## Vision and goals
 

--- a/content/en/docs/concepts/basics/overview.md
+++ b/content/en/docs/concepts/basics/overview.md
@@ -35,7 +35,7 @@ Here are some use cases that are possible with the FVM. With centralized data, a
 
 ### Layer 2: data layer commitments
 
-Layers or Layer Protocols specify the set of communication protocols used on the blockchain and other traditional computer networks. Protocols are the technology that facilitates information sharing. (See [What Are Application Layer Protocols?](https://coinmarketcap.com/alexandria/article/what-are-application-layer-protocols))
+Layers or Layer Protocols specify the set of communication protocols used on the blockchain and other traditional computer networks. Protocols are the technology that facilitates information sharing. The article titled [What Are Application Layer Protocols?](https://coinmarketcap.com/alexandria/article/what-are-application-layer-protocols)) on Coinmarketcap.com is a great resource.
 
 As a technology gets built out, it adds layers of capabilities, including the new Filecoin layer that supports smart contracts:
 


### PR DESCRIPTION
I switched this to staging/docs-content and closed #22 

Sorry, some things stand out more when you see it in production. I fixed:

- which (not "that") in opening paragraph and Layer 0
- Added links to IPFS, IPLD, and sharding
- Smart storage markets was one heading level too high
- Removed "centers" from centralized data centers... redundant
- Made all bullet lists consistent style